### PR TITLE
Clean up specs

### DIFF
--- a/lib/rails/sharding/connection_handler.rb
+++ b/lib/rails/sharding/connection_handler.rb
@@ -78,7 +78,7 @@ module Rails::Sharding
     end
 
     def self.with_connection(shard_group, shard_name, &block)
-    	connection_pool(shard_group, shard_name).with_connection do |connection|
+      connection_pool(shard_group, shard_name).with_connection do |connection|
         if connection && Config.add_shard_tag_to_query_logs
           connection_name = connection_name(shard_group, shard_name)
           add_shard_tag_to_connection_log(connection, connection_name)

--- a/spec/fixtures/models/account.rb
+++ b/spec/fixtures/models/account.rb
@@ -1,4 +1,3 @@
-
 class Account < ActiveRecord::Base
   include Rails::Sharding::ShardableModel
 

--- a/spec/fixtures/models/user.rb
+++ b/spec/fixtures/models/user.rb
@@ -1,7 +1,5 @@
-
-
 class User < ActiveRecord::Base
   include Rails::Sharding::ShardableModel
 
-  belongs_to :accounts
+  belongs_to :account
 end


### PR DESCRIPTION
This is a small PR to make the fixture models a bit nicer. `User` - with its current set up - would never have more than 1 `Account`.

I also noticed the code had a `\t`, cleaning that one up as well.