### PR TITLE
Fix #6 by adding active_support require which ShardThreadRegistry depends on

### DIFF
--- a/lib/rails/sharding/shard_thread_registry.rb
+++ b/lib/rails/sharding/shard_thread_registry.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext/module'
 
 module Rails::Sharding
   class ShardThreadRegistry


### PR DESCRIPTION
Hi @hsgubert !
Thanks for this awesome gem - helped me out big time in upgrading a legacy up while not wanting to give up on sharding

This PR fixes #6 

The issue does not occur because of JRuby but because the necessary active_support dependency has not been loaded yet via one of the railties/engines in `config/application.rb` and bundler has not yet required the dependencies from the Gemfile, which also could've setup active_support.

I suspect OP in #6 probably had Sprockets and other pieces deactivated in their fresh new app.

By explicitly adding the dependency in `ShardThreadRegistry` this gets fixed.

You can reconstruct the scenario by not adding Sprockets to a fresh rails 5.1.7 install:
`rails _5.1.7_ new -S broken_app`
`cd broken_app`
`bundle add rails-sharding`
```
~/broken_app(master ✗) bundle exec rails g rails_sharding:scaffold
/Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rails-sharding-1.1.3/lib/rails/sharding/shard_thread_registry.rb:7:in `<class:ShardThreadRegistry>': undefined method `thread_mattr_accessor' for Rails::Sharding::ShardThreadRegistry:Class (NoMethodError)
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rails-sharding-1.1.3/lib/rails/sharding/shard_thread_registry.rb:2:in `<module:Sharding>'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rails-sharding-1.1.3/lib/rails/sharding/shard_thread_registry.rb:1:in `<top (required)>'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rails-sharding-1.1.3/lib/rails/sharding/core.rb:5:in `require'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rails-sharding-1.1.3/lib/rails/sharding/core.rb:5:in `<top (required)>'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rails-sharding-1.1.3/lib/rails/sharding.rb:4:in `require'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rails-sharding-1.1.3/lib/rails/sharding.rb:4:in `<top (required)>'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/runtime.rb:95:in `require'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/runtime.rb:95:in `rescue in block in require'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/runtime.rb:72:in `block in require'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/runtime.rb:65:in `each'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/runtime.rb:65:in `require'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler.rb:114:in `require'
	from /Users/mwallba/broken_app/config/application.rb:17:in `<top (required)>'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/application.rb:92:in `require'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/application.rb:92:in `preload'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/application.rb:157:in `serve'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/application.rb:145:in `block in run'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/application.rb:139:in `loop'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/application.rb:139:in `run'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/spring-2.1.0/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Users/mwallba/.rbenv/versions/2.6.5/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from -e:1:in `<main>'
```

After adding the dependency fix, everything works fine.

I ran into this issue while checking a client's Gemfile with [bumbler](https://github.com/nevir/Bumbler)