### PR TITLE
Loosen spec to support 5.0, 5.1, 5.2 according to README

### DIFF
--- a/rails-sharding.gemspec
+++ b/rails-sharding.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rails', '~> 5.2.0'
+  spec.add_runtime_dependency 'rails', '~> 5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'byebug', '~> 11'


### PR DESCRIPTION
See #13.  The `~>` constraint should only have two digits and not three to support multiple minor versions of Rails 5.